### PR TITLE
Make the book list uniform. Sort by reverse year

### DIFF
--- a/learning/index.html
+++ b/learning/index.html
@@ -54,46 +54,161 @@ or run them directly on <a href="https://juliabox.com">JuliaBox</a>.
   </ul>
 
 <h1 id="books">Books</h1>
-
 <ul>
-  <li><a href="http://vmls-book.stanford.edu/">Introduction to Applied Linear Algebra – Vectors, Matrices, and Least Squares</a> by Stephen Boyd and Lieven Vandenberghe (474 pages; Cambridge University Press; published August 23, 2018), with a <a href="http://vmls-book.stanford.edu/vmls-julia-companion.pdf">Julia Language Companion</a>.
-  <li><a href="https://www.amazon.com/Algorithms-Optimization-Press-Mykel-Kochenderfer/dp/0262039427/">Algorithms for Optimization</a> by Mykel Kochenderfer and Tim Wheeler (520 pages; MIT Press; published Mar 12, 2019).
-  <li><a href="http://www.chkwon.net/julia">Julia Programming for Operations Research, Second Edition</a> by Changhyun Kwon (260 pages; published: 2019-03; ISBN: 978-1798205471)
-  This book aims to teach how one can solve various optimization problems arising in operations research and management science, based on Julia v1.0+ and JuMP v0.19+</li>
-    <li><a href="http://shop.oreilly.com/product/0636920215707.do">Think Julia - How to Think Like a Computer Scientist</a> by Allen Downey and Ben Lauwens.
-    <li><a href="http://bookstore.siam.org/ot154/">Fundamentals of Numerical Computation</a> by Tobin A. Driscoll and Richard J. Braun. <a href="https://github.com/tobydriscoll/fnc-extras/tree/master/julia">Julia code</a> for the book is available on GitHub.
-    <li><a href="https://people.smp.uq.edu.au/YoniNazarathy/julia-stats/StatisticsWithJulia.pdf">Statistics with Julia: Fundamentals for Data Science, Machine Learning and Artificial Intelligence</a> by Hayden Klok and Yoni Nazarathy. (DRAFT. PDF will be taken down when the book is published later in 2019).
-    <li><a href="https://www.crcpress.com/Data-Science-with-Julia/McNicholas-Tait/p/book/9781138499980">Data Science with Julia</a> by Paul D. McNicholas and Peter A. Tait
- (220 pages; published: January 2019; ISBN: 9781138499980)
- Covers the core components of Julia v1.0. Reviews data visualization, supervised and unsupervised learning. Details R interoperability.  </li>
-  <li><a href="https://www.packtpub.com/application-development/julia-high-performance-programming">Julia: High Performance Programming</a> by Ivo Balbaert, Avik Sengupta, Malcolm Sherrington
- (697 pages; published: November 2016; ISBN: 9781787125704)
- In this learning path, you will learn to use an interesting and dynamic programming language—Julia! This book is a combination and curation of the three separate books by the three authors.</li>
-  <li><a href="https://www.packtpub.com/application-development/julia-high-performance">Julia High Performance</a> by Avik Sengupta (120 pages; published: 2016-05; ISBN: 9781785880919)
-  This is a book about performance optimisation of Julia programs, showing how to design and write Julia code that fully realises the potential speed of the language and its libraries.</li>
-  <li><a href="https://www.packtpub.com/application-development/mastering-julia">Mastering Julia</a> by Malcolm Sherrington - published by Packt Publishing (410 pages; published: 2015-07; ISBN: 9781783553310)</li>
-  <li><a href="https://www.packtpub.com/application-development/getting-started-julia-programming/">Getting Started with Julia Programming</a> by Ivo Balbaert - published by Packt Publishing (214 pages; published: 2015-02-28; ISBN: 9781783284795)</li>
-  <li><a href="https://pragprog.com/book/7lang/seven-more-languages-in-seven-weeks">Seven More Languages in Seven Weeks</a> by Bruce Tate, Fred Daoud, Jack Moffit and Ian Dees - published by The Pragmatic Programmers (350 pages; published: 2014-11-15; ISBN: 978-1-94122-215-7)
-  This book contains a Julia tutorial chapter (written by Jack Moffitt and Bruce Tate) for programmers new to Julia, which is very good, with nice examples and exercises.</li>
-  <li><a href="https://www.packtpub.com/big-data-and-business-intelligence/julia-data-science">Julia for Data Science</a> by Anshul Joshi (348 pages; published: 2016-09; ISBN: 9781785289699)
-  Explore the world of data science from scratch with Julia by your side</li>
-  <li><a href="https://technicspub.com/analytics/">Julia for Data Science</a> by Zacharias Voulgaris PhD (415 pages; published: 2016-09-01; ISBN: 9781634621304). Master the essentials of data science through the Julia programming ecosystem (no prior knowledge of the language is required), accompanied by a variety of interesting examples and exercises.</li>
-  <li><a href="https://www.packtpub.com/application-development/julia-cookbook/">Julia Cookbook</a> by Jalem Raj Rohit - published by Packt Publishing (172 pages; published: 2016-09; ISBN: 9781785882012)</li>
-  <li><a href="https://www.packtpub.com/big-data-and-business-intelligence/julia-solutions-video">Julia Solutions</a> by Jalem Raj Rohit - A comprehensive guide to learn data science for a Julia programmer - Produced by Packt Publishing (2 hours and 52 minutes long; published: January 31, 2017; ISBN: 9781787283299)</li>
-  <li><a href="https://www.packtpub.com/application-development/getting-started-julia-video">Getting Started with Julia</a> by Erik Engheim - Learn the new language Julia for high performance technical computing - Produced by Packt Publishing (9 hours and 50 minutes long; published: March 31, 2017; ISBN: 9781786462978)</li>
-  <li><a href="https://www.packtpub.com/application-development/learning-julia">Learning Julia</a> by Anshul Joshi, Rahul Lakhanpal (316 pages; published: November 2017; ISBN: 9781785883279). This book shows you how to write effective functions, reduce code redundancies, and improve code reuse.  It will be helpful for new programmers who are starting out with Julia to explore its wide and ever-growing package ecosystem and also for experienced developers/statisticians/data scientists who want to add Julia to their skill-set.</li>
-  <li><a href="https://www.amazon.com/dp/1788998790">Hands-On Computer Vision with Julia</a> by Dmitrijs Cudihins (202 pages; published: June 2018; ISBN: 9781788998796). Explore the various packages in Julia that support image processing and build neural networks for video processing and object tracking.</li>
-  <li><a href="http://bookstore.siam.org/sl03">Iterative Solution of Symmetric Quasi-Definite Linear Systems</a> by Dominique Orban and Mario Arioli. This book is intended for researchers and advanced graduate students in computational optimization, computational fluid dynamics, computational linear algebra, data assimilation, and virtually any computational field in which saddle-point systems occur. <a href="https://github.com/JuliaSmoothOptimizers/Krylov.jl">Krylov.jl</a> is the Julia package that accompanies the book. <a href="https://epubs.siam.org/doi/book/10.1137/1.9781611974737">Ebook</a> for SIAM subscribers.  </li>
-  <li><a href="https://www.packtpub.com/application-development/julia-10-programming-cookbook">Julia 1.0 Programming Cookbook</a> by B. Kamiński, P. Szufel (460 pages; published: November 2018; ISBN: 9781788998369)</li>
-  <li><a href="https://www.oreilly.co.jp/books/9784873118895/">Julia プログラミングクックブック</a> by B. Kamiński, P. Szufel (Japanese translation for Julia 1.2 by Hidemoto Nakada; 392 pages; published: October 2019; ISBN: 978-4-87311-889-5)</li>
-  <li><a href="https://www.packtpub.com/big-data-and-business-intelligence/julia-programming-projects"> Julia Programming Projects</a> by Adrian Salceanu (500 pages; published: December 2018; ISBN: 9781788292740).
-    A beginners book providing a hands-on introduction to Julia programming through increasingly challenging real-world projects.
-    Covers some of the most important aspects of the language and key packages, across various domains including data analysis, plotting, databases, web, and more.
-    Ideal for readers with previous programming experience, looking for a thorough introduction to Julia.
-    </li>
-    <li><a href="https://doi.org/10.33009/jul">First Semester in Numerical Analysis with Julia</a> by Giray Ökten (211 pages; published: April 2019). This open textbook for use in undergraduate courses covers computer arithmetic, root-finding, numerical quadrature and differentiation, and approximation theory.</li>
-  <li><a href="https://julia-book.com">Julia Quick Syntax Reference. A Pocket Guide for Data Science Programming</a> by Antonello Lobianco (216 pages; published: November 2019; ISBN:978-1-4842-5189-8; Editor: Apress). A fairly complete, yet accessible, overview of the language and of the main packages that encompass its "ecosystem".</li>
+   <li>
+      Malcolm Sherrington.
+      <em>Mastering Julia 1.0</em>.
+      Packt Publishing, November 2019.
+      <a href="https://www.packtpub.com/application-development/mastering-julia-10">Link</a>
+   </li>
+   <li>
+      Antonello Lobianco.
+      <em>Julia Quick Syntax Reference</em>.
+      Apress, November 2019.
+      <a href="https://www.apress.com/gp/book/9781484251898">Link</a>
+   </li>
+   <li>
+      Bogumil Kaminski.
+      <em>Julia プログラミングクックブック</em>.
+      Orairījapan, Tōkyo, October 2019.
+      <a href="https://www.oreilly.co.jp/books/9784873118895/">Link</a>
+   </li>
+   <li>
+      Hayden Klok and Yoni Nazarathy.
+      Statistics with julia: Fundamentals for data science, machine
+      learning and artificial intelligence.
+      September 2019.
+      &nbsp;<a href="julia_bib.html#klok2019sjf">bib</a>
+   </li>
+   <li>
+      Ben Lauwens and Allen&nbsp;B. Downey.
+      <em>Think Julia</em>.
+      O'Reilly Media, June 2019.
+      <a href="https://www.oreilly.com/library/view/think-julia/9781492045021/">Link</a>
+   </li>
+   <li>
+      Giray Ökten.
+      <em>First Semester in Numerical Analysis with Julia</em>.
+      Florida State University Libraries, April 2019. 
+      <a href="http://purl.flvc.org/fsu/fd/FSU_libsubv1_scholarship_submission_1556028278_15938059">Link</a>
+   </li>
+   <li>
+      Changhyun Kwon.
+      <em>Julia Programming for Operations Research</em>.
+      March 2019.
+      <a href="https://www.chkwon.net/julia/">Link</a>
+   </li>
+   <li>
+      Mykel&nbsp;J. Kochenderfer and Tim&nbsp;A. Wheeler.
+      <em>Algorithms for Optimization</em>.
+      MIT Press, March 2019.
+      <a href="https://mitpress.mit.edu/books/algorithms-optimization">Link</a>
+   </li>
+   <li>
+      Paul&nbsp;D. McNicholas and Peter Tait.
+      <em>Data Science with Julia</em>.
+      Chapman and Hall/CRC, January 2019.
+      <a href="https://www.crcpress.com/Data-Science-with-Julia/McNicholas-Tait/p/book/9781138499980">Link</a>
+   </li>
+   <li>
+      Adrian Salceanu.
+      <em>Julia Programming Projects</em>.
+      Packt Publishing, December 2018.
+      <a href="https://www.packtpub.com/big-data-and-business-intelligence/julia-programming-projects">Link</a>
+   </li>
+   <li>
+      Przemysław Szufel and Bogumił Kamiński.
+      <em>Julia 1.0 Programming Cookbook</em>.
+      Packt Publishing, November 2018.
+      <a href="https://www.packtpub.com/application-development/julia-10-programming-cookbook">Link</a>
+   </li>
+   <li>
+      Ivo Balbaert.
+      <em>Julia 1.0 Programming</em>.
+      Packt Publishing, September 2018.
+      <a href="https://www.packtpub.com/application-development/julia-10-programming-second-edition">Link</a>
+   </li>
+  <li>Julia 1.0 was released on 8 August 2018</li>
+   <li>
+      Dmitrijs Cudihins.
+      <em>Hands-on Computer Vision with Julia</em>.
+      Packt Publishing, June 2018.
+      <a href="https://www.packtpub.com/application-development/hands-computer-vision-julia">Link</a>
+   </li>
+   <li>
+      Stephen Boyd and Lieven Vandenberghe.
+      <em>Introduction to Applied Linear Algebra</em>.
+      Cambridge University Press, June 2018.
+      <a href="https://web.stanford.edu/~boyd/vmls/">Link</a>
+   </li>
+   <li>
+      Anshul Joshi and Rahul Lakhanpal.
+      <em>Learning Julia</em>.
+      Packt Publishing, November 2017.
+      <a href="https://www.packtpub.com/application-development/learning-julia">Link</a>
+   </li>
+   <li>
+      Dominique Orban and Mario Arioli.
+      <em>Iterative Solution of Symmetric Quasi-definite Linear Systems</em>.
+      Society for Industrial and Applied Mathematics, April 2017.
+      <a href="http://dx.doi.org/10.1137/1.9781611974737">DOI</a>
+   </li>
+   <li>
+      Tobin&nbsp;A. Driscoll and Richard&nbsp;J. Braun.
+      <em>Fundamentals of Numerical Computation</em>.
+      SIAM-Society for Industrial and Applied Mathematics, 2017.
+      <a href="https://my.siam.org/Store/Product/viewproduct/?ProductId=29215528">Link</a>
+   </li>
+   <li>
+      Jalem&nbsp;Raj Rohit.
+      <em>Julia Cookbook</em>.
+      Packt Publishing, September 2016.
+      <a href="https://www.packtpub.com/application-development/julia-cookbook">Link</a>
+   </li>
+   <li>
+      Zacharias Voulgaris.
+      <em>Julia for Data Science</em>.
+      Technics Publications, September 2016.
+      <a href="https://technicspub.com/julia-for-data-science/">Link</a>
+   </li>
+   <li>
+      Avik Sengupta.
+      <em>Julia High Performance</em>.
+      Packt Publishing, April 2016.
+      <a href="https://www.packtpub.com/application-development/julia-high-performance">Link</a>
+   </li>
+   <li>
+      Anshul Joshi.
+      <em>Julia for Data Science</em>.
+      Packt Publishing, 2016.
+      <a href="https://www.packtpub.com/big-data-and-business-intelligence/julia-data-science">Link</a>
+   </li>
+   <li>
+      Ivo Balbaert, Avik Sengupta, and Malcolm Sherrington.
+      <em>Julia: High Performance Programming</em>.
+      Packt Publishing, 2016.
+      <a href="https://www.amazon.com/Julia-Performance-Programming-Ivo-Balbaert-ebook/dp/B01MXS4IPT?SubscriptionId=AKIAIOBINVZYXZQZ2U3A\&amp;tag=chimbori05-20\&amp;linkCode=xm2\&amp;camp=2025\&amp;creative=165953\&amp;creativeASIN=B01MXS4IPT">Link</a>
+   </li>
+   <li>
+      Ivo Balbaert.
+      <em>Getting Started with Julia Programming Language</em>.
+      Packt Publishing, 2015.
+      <a href="https://www.packtpub.com/application-development/getting-started-julia">Link</a>
+   </li>
+   <li>
+      Malcolm Sherrington.
+      <em>Mastering Julia</em>.
+      Packt Publishing, 2015.
+      <a href="https://www.packtpub.com/application-development/mastering-julia">Link</a>
+   </li>
+   <li>
+      Bruce Tate, Ian Dees, Frederic Daoud, and Jack Moffit.
+      <em>Seven More Languages in Seven Weeks</em>.
+      The Pragmatic Programmers, December 2014.
+      <a href="https://pragprog.com/book/7lang/seven-more-languages-in-seven-weeks">Link</a>
+   </li>
 </ul>
+
   
 
 <h1 id="resources">Resources</h1>


### PR DESCRIPTION
This PR:

- adds URLs to publisher's page
- adds Julia 1.0 release as a reference point
- sorts the list with latest books on top